### PR TITLE
Cure framerate irregularities

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -69,7 +69,6 @@ int main()
     while (App.isOpen())
     {
         // std::cout << state << std::endl;
-        clock.restart();
         sf::Event Event;
         while (App.pollEvent(Event))
         {
@@ -112,7 +111,7 @@ int main()
         }
 
         App.clear(sf::Color(0, 0, 0));
-        player.tick(clock.getElapsedTime().asMilliseconds());
+        player.tick(clock.restart().asMilliseconds());
         App.draw(playerToCircle(player));
         App.display();
     }


### PR DESCRIPTION
Current code in `some-obstacles-3` didn't work properly for me: circle moved _very_ slowly. The problem was caused by the fact that we only measured event processing time, leaving out drawing and displaying times. This PR fixes that.
