### PR TITLE
Fixed clang build

### DIFF
--- a/util.cpp
+++ b/util.cpp
@@ -1,9 +1,11 @@
 #include <SFML/Graphics/Color.hpp>
 #include "util.hpp"
 
-sf::Color operator*(const sf::Color &color, float f)
+namespace sf {
+Color operator*(const Color &color, float f)
 {
   return sf::Color(color.r * f,
                    color.g * f,
                    color.b * f);
+}
 }

--- a/util.hpp
+++ b/util.hpp
@@ -3,8 +3,9 @@
 
 namespace sf {
     class Color;
+
+    Color operator*(const Color &color, float f);
 }
 
-sf::Color operator*(const sf::Color &color, float f);
 
 #endif  // UTIL_HPP_


### PR DESCRIPTION
turns out clang just wanted the operator\* to be defined in the `sf::` namespace.
