### PR TITLE
Introduce set animation

### DIFF
--- a/src/beatwave/player.cpp
+++ b/src/beatwave/player.cpp
@@ -36,12 +36,14 @@ void Player::step(const sf::Color &flashColor,
 {
     using namespace dsl;
 
-    color.animate(from(flashColor)
-                  .to(sf::Color::White)
-                  .during(config::COLOR_TIME));
-    position.animate(from(position.value())
-                     .by(direction)
-                     .during(config::MOVE_TIME));
+    if (!dead) {
+        color.animate(from(flashColor)
+                      .to(sf::Color::White)
+                      .during(config::COLOR_TIME));
+        position.animate(from(position.value())
+                         .by(direction)
+                         .during(config::MOVE_TIME));
+    }
 }
 
 void Player::centerView(sf::RenderTarget *renderTarget) const
@@ -53,9 +55,9 @@ void Player::reset()
 {
     using namespace dsl;
 
-    position.animate(from(position.value()).to(config::PLAYER_INIT_POSITION).during(config::MOVE_TIME));
-    color.animate(from(color.value()).to(config::PLAYER_INIT_COLOR).during(config::MOVE_TIME));
-    radius.animate(from(radius.value()).to(config::PLAYER_INIT_RADIUS).during(config::MOVE_TIME));
+    position.animate(set(config::PLAYER_INIT_POSITION));
+    color.animate(set(config::PLAYER_INIT_COLOR));
+    radius.animate(set(config::PLAYER_INIT_RADIUS));
     dead = false;
 }
 

--- a/src/core/dsl.hpp
+++ b/src/core/dsl.hpp
@@ -5,6 +5,7 @@
 #include <core/seqcombinatorbuilder.hpp>
 #include <core/forever.hpp>
 #include <core/repeat.hpp>
+#include <core/set.hpp>
 
 namespace dsl {
 
@@ -30,6 +31,12 @@ template <typename State>
 AnimationPtr<State> repeat(int counter, AnimationPtr<State> &&animation)
 {
     return AnimationPtr<State>(new Repeat<State>(counter, std::move(animation)));
+}
+
+template <typename State>
+AnimationPtr<State> set(const State &state)
+{
+    return AnimationPtr<State>(new Set<State>(state));
 }
 
 }

--- a/src/core/set.hpp
+++ b/src/core/set.hpp
@@ -12,11 +12,6 @@ public:
         m_finished(false)
     {}
 
-    virtual ~Set() override
-    {
-        std::cout << "~Set()" << std::endl;
-    }
-
     virtual State nextState(const int32_t) override
     {
         m_finished = true;

--- a/src/core/set.hpp
+++ b/src/core/set.hpp
@@ -1,0 +1,46 @@
+#ifndef SET_HPP_
+#define SET_HPP_
+
+#include <iostream>
+
+template <typename State>
+class Set: public Animation<State>
+{
+public:
+    Set(const State &state):
+        m_state(state),
+        m_finished(false)
+    {}
+
+    virtual ~Set() override
+    {
+        std::cout << "~Set()" << std::endl;
+    }
+
+    virtual State nextState(const int32_t) override
+    {
+        m_finished = true;
+        return m_state;
+    }
+
+    virtual State getCurrentState() const override
+    {
+        return m_state;
+    }
+
+    virtual bool isFinished() const override
+    {
+        return m_finished;
+    }
+
+    virtual void reset() override
+    {
+        m_finished = false;
+    }
+
+private:
+    const State m_state;
+    bool m_finished;
+};
+
+#endif  // SET_HPP_


### PR DESCRIPTION
Also, immediately set the player properties on reset instead of linear transition to them. Close #50 
